### PR TITLE
Switch to 3rd person when entering ortho mode

### DIFF
--- a/src/main/java/com/dimaskama/orthocamera/client/OrthoCamera.java
+++ b/src/main/java/com/dimaskama/orthocamera/client/OrthoCamera.java
@@ -8,6 +8,7 @@ import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.option.Perspective;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.text.Text;
 import org.apache.logging.log4j.LogManager;
@@ -33,6 +34,8 @@ public class OrthoCamera implements ClientModInitializer {
     private static final Text FIXED_TEXT = Text.translatable("orthocamera.fixed");
     private static final Text UNFIXED_TEXT = Text.translatable("orthocamera.unfixed");
     private static final float SCALE_MUL_INTERVAL = 1.1F;
+
+    private Perspective prevPerspective;
 
     @Override
     public void onInitializeClient() {
@@ -62,6 +65,11 @@ public class OrthoCamera implements ClientModInitializer {
                     true
             );
             messageSent = true;
+
+            if (CONFIG.enabled) {
+                prevPerspective = client.options.getPerspective();
+                client.options.setPerspective(Perspective.THIRD_PERSON_BACK);
+            } else client.options.setPerspective(prevPerspective);
         }
         boolean on = CONFIG.enabled;
         boolean scaleChanged = false;


### PR DESCRIPTION
This fixes the confusing problem where your arm renders over top of the orthogonal perspective (Mentioned in #12). It also switches back to the perspective the client was in before entering ortho mode.