### PR TITLE
Improved Sodium compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ repositories {
     maven {
         url "https://maven.terraformersmc.com/releases/"
     }
+    maven {
+        url "https://maven.terraformersmc.com/releases/"
+    }
 }
 
 dependencies {
@@ -19,6 +22,7 @@ dependencies {
 
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
     modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
+    modImplementation "maven.modrinth:sodium:${project.sodium_version}"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
         url "https://maven.terraformersmc.com/releases/"
     }
     maven {
-        url "https://maven.terraformersmc.com/releases/"
+        url "https://api.modrinth.com/maven"
     }
 }
 
@@ -64,7 +64,7 @@ jar {
 }
 
 modrinth {
-    token = project.modrinth_forminotaur_token
+    //token = project.modrinth_forminotaur_token
     projectId = "orthocamera"
     versionNumber = project.mod_version
     versionType = "release" // This is the default -- can also be `beta` or `alpha`

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ jar {
 }
 
 modrinth {
-    //token = project.modrinth_forminotaur_token
+    token = project.modrinth_forminotaur_token
     projectId = "orthocamera"
     versionNumber = project.mod_version
     versionType = "release" // This is the default -- can also be `beta` or `alpha`

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,7 @@ archives_base_name = OrthoCamera
 # check this on https://modmuss50.me/fabric.html
 fabric_version=0.100.1+1.21
 modmenu_version=11.0.0-rc.4
+# check this on https://modrinth.com/mod/sodium/versions
+sodium_version=mc1.21-0.5.11
 
 changelog=Update to 1.21

--- a/src/main/java/com/dimaskama/orthocamera/client/OrthoCamera.java
+++ b/src/main/java/com/dimaskama/orthocamera/client/OrthoCamera.java
@@ -2,10 +2,12 @@ package com.dimaskama.orthocamera.client;
 
 import com.dimaskama.orthocamera.client.config.ModConfig;
 import com.dimaskama.orthocamera.client.config.ModConfigScreen;
+import com.dimaskama.orthocamera.integration.SodiumIntegration;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
@@ -34,6 +36,8 @@ public class OrthoCamera implements ClientModInitializer {
     private static final Text UNFIXED_TEXT = Text.translatable("orthocamera.unfixed");
     private static final float SCALE_MUL_INTERVAL = 1.1F;
 
+    private boolean sodiumPresent = false;
+
     @Override
     public void onInitializeClient() {
         CONFIG.loadOrCreate();
@@ -50,6 +54,7 @@ public class OrthoCamera implements ClientModInitializer {
         ClientTickEvents.START_CLIENT_TICK.register(c -> CONFIG.tick());
         ClientTickEvents.END_CLIENT_TICK.register(this::handleInput);
         ClientLifecycleEvents.CLIENT_STOPPING.register(this::onClientStopping);
+        sodiumPresent = FabricLoader.getInstance().getModContainer("sodium").isPresent();
     }
 
     private void handleInput(MinecraftClient client) {
@@ -62,6 +67,11 @@ public class OrthoCamera implements ClientModInitializer {
                     true
             );
             messageSent = true;
+
+            if (sodiumPresent) {
+                if (CONFIG.enabled) SodiumIntegration.on();
+                else SodiumIntegration.off();
+            }
         }
         boolean on = CONFIG.enabled;
         boolean scaleChanged = false;

--- a/src/main/java/com/dimaskama/orthocamera/integration/SodiumIntegration.java
+++ b/src/main/java/com/dimaskama/orthocamera/integration/SodiumIntegration.java
@@ -1,0 +1,17 @@
+package com.dimaskama.orthocamera.integration;
+
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
+
+public class SodiumIntegration {
+
+    private static boolean prevSetting;
+
+    public static void on() {
+        prevSetting = SodiumClientMod.options().performance.useBlockFaceCulling;
+        SodiumClientMod.options().performance.useBlockFaceCulling = false;
+    }
+
+    public static void off() {
+        SodiumClientMod.options().performance.useBlockFaceCulling = prevSetting;
+    }
+}


### PR DESCRIPTION
This pr disables "Use Block Face Culling" while in ortho mode, and sets it back to the user specified setting when exiting. This makes the mod work with sodium out of the box with no need to tweak settings. 

This closes #12 