### PR TITLE
Add option to hide world border (1.21.4)

### DIFF
--- a/src/main/java/com/dimaskama/orthocamera/client/config/ModConfig.java
+++ b/src/main/java/com/dimaskama/orthocamera/client/config/ModConfig.java
@@ -18,6 +18,7 @@ public class ModConfig extends JsonConfig {
 
     public boolean enabled = false;
     public boolean save_enabled_state;
+    public boolean hide_world_border;
     public float scale_x = 3.0F;
     public float scale_y = 3.0F;
     public float min_distance = -1000.0F;

--- a/src/main/java/com/dimaskama/orthocamera/client/config/ModConfigScreen.java
+++ b/src/main/java/com/dimaskama/orthocamera/client/config/ModConfigScreen.java
@@ -96,6 +96,12 @@ public class ModConfigScreen extends Screen {
                 90.0F, 0.0F,
                 v -> config.fixed_rotate_speed_x = v
         ));
+        y += 25;
+        addDrawableChild(ButtonWidget.builder(Text.translatable("orthocamera.config.hide_world_border", textOfBool(config.hide_world_border)), button -> {
+            config.hide_world_border = !config.hide_world_border;
+            config.setDirty(true);
+            button.setMessage(Text.translatable("orthocamera.config.hide_world_border", textOfBool(config.hide_world_border)));
+        }).dimensions(leftX, y, optionWidth, 20).build());
 
         addDrawableChild(ButtonWidget.builder(Text.translatable("orthocamera.reset_config"), button -> {
             config.reset();

--- a/src/main/java/com/dimaskama/orthocamera/mixin/WorldBorderRenderingMixin.java
+++ b/src/main/java/com/dimaskama/orthocamera/mixin/WorldBorderRenderingMixin.java
@@ -1,0 +1,28 @@
+package com.dimaskama.orthocamera.mixin;
+
+import com.dimaskama.orthocamera.client.OrthoCamera;
+import net.minecraft.client.render.WorldBorderRendering;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.border.WorldBorder;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(WorldBorderRendering.class)
+public class WorldBorderRenderingMixin {
+
+    @Inject(
+            method = "render",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void render(WorldBorder border, Vec3d vec3d, double d, double e, CallbackInfo ci) {
+        if (!OrthoCamera.isEnabled() || !OrthoCamera.CONFIG.hide_world_border) {
+            return;
+        }
+
+        ci.cancel();
+    }
+
+}

--- a/src/main/resources/assets/orthocamera/lang/en_us.json
+++ b/src/main/resources/assets/orthocamera/lang/en_us.json
@@ -18,6 +18,7 @@
   "orthocamera.unfixed": "Orthographic Camera Unfixed",
   "orthocamera.config.enabled": "Enabled: %s",
   "orthocamera.config.save_enabled_state": "Save enabled state: %s",
+  "orthocamera.config.hide_world_border": "Hide world border: %s",
   "orthocamera.config.scale_x": "X Scale: %s",
   "orthocamera.config.scale_y": "Y Scale: %s",
   "orthocamera.config.min_distance": "Minimum distance: %s",

--- a/src/main/resources/orthocamera.mixins.json
+++ b/src/main/resources/orthocamera.mixins.json
@@ -7,7 +7,8 @@
   ],
   "client": [
     "CameraMixin",
-    "GameRendererMixin"
+    "GameRendererMixin",
+    "WorldBorderRenderingMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
# Add option to hide world border (1.21.4)

## Description
This PR introduces a new option to hide the world border in version 1.21.4. Users can now toggle the visibility of the world border, to prevent it from blocking the view of the camera.

## Changes
- Added a configuration option to hide the world border.
- Updated relevant rendering logic to respect the new setting.
- Ensured default behavior remains unchanged when the option is not enabled.

## Testing
- Verified that enabling the option correctly hides the world border.
- Verified that disabling the option restores normal world border rendering.
