### PR TITLE
Frustum fix

### DIFF
--- a/src/main/java/com/dimaskama/orthocamera/mixin/MixinPlugin.java
+++ b/src/main/java/com/dimaskama/orthocamera/mixin/MixinPlugin.java
@@ -1,0 +1,51 @@
+package com.dimaskama.orthocamera.mixin;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class MixinPlugin implements IMixinConfigPlugin {
+
+    private static final String SODIUM_MIXIN_PACKAGE = "com.dimaskama.orthocamera.mixin.sodium.";
+
+    private boolean sodiumLoaded;
+
+    @Override
+    public void onLoad(String mixinPackage) {
+        this.sodiumLoaded = FabricLoader.getInstance().isModLoaded("sodium");
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        if (mixinClassName.startsWith(SODIUM_MIXIN_PACKAGE)) {
+            return sodiumLoaded;
+        }
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+    }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+    }
+}

--- a/src/main/java/com/dimaskama/orthocamera/mixin/sodium/SodiumSimpleFrustumMixin.java
+++ b/src/main/java/com/dimaskama/orthocamera/mixin/sodium/SodiumSimpleFrustumMixin.java
@@ -1,0 +1,40 @@
+package com.dimaskama.orthocamera.mixin.sodium;
+
+import com.dimaskama.orthocamera.client.OrthoCamera;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(
+    targets = "net.caffeinemc.mods.sodium.client.render.viewport.frustum.SimpleFrustum",
+    remap = false
+)
+public class SodiumSimpleFrustumMixin {
+
+    @Inject(
+        method = "testSection",
+        at = @At("HEAD"),
+        cancellable = true,
+        remap = false,
+        require = 0
+    )
+    private void bypassTestSection(CallbackInfoReturnable<Boolean> cir) {
+        if (OrthoCamera.isEnabled()) {
+            cir.setReturnValue(true);
+        }
+    }
+
+    @Inject(
+        method = "testSectionExpanded",
+        at = @At("HEAD"),
+        cancellable = true,
+        remap = false,
+        require = 0
+    )
+    private void bypassTestSectionExpanded(CallbackInfoReturnable<Boolean> cir) {
+        if (OrthoCamera.isEnabled()) {
+            cir.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/resources/orthocamera.mixins.json
+++ b/src/main/resources/orthocamera.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.dimaskama.orthocamera.mixin",
+  "plugin": "com.dimaskama.orthocamera.mixin.MixinPlugin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
   ],
@@ -10,7 +11,8 @@
     "FrustumMixin",
     "GameRendererMixin",
     "ProjectionMixin",
-    "WorldBorderRenderingMixin"
+    "WorldBorderRenderingMixin",
+    "sodium.SodiumSimpleFrustumMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
## Sodium Frustum Culling Solution

As noted by @vartiens in #47, there is a bug in newer versions of the mod involving compatibility with the Sodium. Specifically, new aggressive culling procedures are causing Orthocamera to not render properly. I've developed a fix to this problem that resolves this issue, as well as some older chunk culling quirks that I was also able to fix.

### Installation
If you don't want any details and just the fixed version, go to my fork and download the jar file from the latest release (26.1.2):
Source code: [https://github.com/ruhan-p/orthocamera-sodium-culling-fix](https://github.com/ruhan-p/orthocamera-sodium-culling-fix)
Release: [https://github.com/ruhan-p/orthocamera-sodium-culling-fix/releases/tag/26.1.1](https://github.com/ruhan-p/orthocamera-sodium-culling-fix/releases/tag/26.1.2)

###  Background
                                            
Sodium is using two main mechanisms to determine what chunks to render: BFS graph traversal and SimpleFrustum plane tests. The latter was the main cause of the modern issue, though the former also caused some strange behavior that some may want resolved. Quickly discussing how both work:

1. BFS graph transversal
Sodium walks outward through neighboring chunks, and if it notices that a chunk is either a solid wall or cannot geometrically be seen from an angle, it stops the walk in that direction (assuming nothing behind it can be seen)

2. SimpleFrustum plane tests
This is the main culprit. Sodium checks if the current chunks are within the player's viewing area. If not, they are skipped. Minecraft already has its own built-in implementation, which Orthocamera was able to sidestep, but it does not account for Sodium's implementation.

### The Fix
The solution is pretty simple; just add a conditional mixin to intercept the Frustum culling and bypass it when Orthocamera is enabled:
```
package com.dimaskama.orthocamera.mixin.sodium;

import com.dimaskama.orthocamera.client.OrthoCamera;
import org.spongepowered.asm.mixin.Mixin;
import org.spongepowered.asm.mixin.injection.At;
import org.spongepowered.asm.mixin.injection.Inject;
import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;

@Mixin(
    targets = "net.caffeinemc.mods.sodium.client.render.viewport.frustum.SimpleFrustum",
    remap = false
)
public class SodiumSimpleFrustumMixin {

    @Inject(
        method = "testSection",
        at = @At("HEAD"),
        cancellable = true,
        remap = false,
        require = 0
    )
    private void bypassTestSection(CallbackInfoReturnable<Boolean> cir) {
        if (OrthoCamera.isEnabled()) {
            cir.setReturnValue(true);
        }
    }

    @Inject(
        method = "testSectionExpanded",
        at = @At("HEAD"),
        cancellable = true,
        remap = false,
        require = 0
    )
    private void bypassTestSectionExpanded(CallbackInfoReturnable<Boolean> cir) {
        if (OrthoCamera.isEnabled()) {
            cir.setReturnValue(true);
        }
    }
}
```
This fixes the issue with Orthocamera, while preserving Sodium’s culling enhancements while disabled.
An additional MixinPlugin class handles safe conditional loading of both mixins using a classpath resource check (rather than Class.forName, which would load the target class too early and prevent Mixin from transforming it).

### Optional Occlusion Culling Fix
As I mentioned earlier, Sodium had some earlier culling features that prevented Orthocamera from working properly, specifically the Occlusion Culling. Essentially, this would prevent Orthocamera from rendering chunks that were completely out of view or underground. With this fix, underground and out of view chunks will be rendered as well. These changes are not included in the fixed version I have attached, but the changes can be made fairly easily.

An additional Mixin can be added. Create the following file at src/main/java/com/dimaskama/orthocamera/mixin/sodium/SodiumOcclusionCullerMixin.java:
```
package com.dimaskama.orthocamera.mixin.sodium;

import com.dimaskama.orthocamera.client.OrthoCamera;
import org.spongepowered.asm.mixin.Mixin;
import org.spongepowered.asm.mixin.injection.At;
import org.spongepowered.asm.mixin.injection.ModifyVariable;

@Mixin(
    targets = "net.caffeinemc.mods.sodium.client.render.chunk.occlusion.OcclusionCuller",
    remap = false
)
public class SodiumOcclusionCullerMixin {

    @ModifyVariable(
       method = "findVisible",
        argsOnly = true,
        ordinal = 0,
        at = @At("HEAD"),
        remap = false,
        require = 0
    )
    private boolean disableOcclusionCulling(boolean original) {
        return OrthoCamera.isEnabled() ? false : original;
    }
}
```
Then register it in src/main/resources/orthocamera.mixins.json by adding "sodium.SodiumOcclusionCullerMixin" to the client array alongside the existing Sodium entries. No other changes are needed, since MixinPlugin handles the entire sodium folder.
Note that this disables Sodium's geometry-based occlusion culling entirely while Orthocamera is active, which may have a performance cost in complex scenes. Sodium's occlusion culling is one of its more significant optimizations, so this trade-off is pretty significant.